### PR TITLE
Add check to testing download workflow step to run limited tests for forks and dependabot

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,10 +19,11 @@ jobs:
         with:
           tool: golangci-lint
           owner: golangci
-          github_token: ${{ secrets.CI_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           release_format: $TOOL-$SVERSION-$OS-$ARCH
           has_root_folder: true
       - name: Mesa-CLI
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' # Only run private check for prs from repo not made by dependabot
         uses: ./github-release-download
         with:
           repo: mesa-cli


### PR DESCRIPTION
Due to the changes as part of https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/ dependabot prs no longer have access to Workflow secrets as they are run similarly to how a fork pr runs. However as part of our workflow verifications we attempt to download a project only available internally.

Based on a solution mentioned in https://github.community/t/how-to-detect-a-pull-request-from-a-fork/18363 I have added a check to the private download stop to ignore it when a pr is opened from a fork or by dependabot. The check for public repos runs successfully with the default Github token and verify that all prs at the minimum didn't break overall functionality.