### PR TITLE
Update action.yml

### DIFF
--- a/github-release-download/action.yml
+++ b/github-release-download/action.yml
@@ -34,7 +34,7 @@ outputs:
   download_path:
     description: Location of the uncompressed files
 runs:
-  using: node12
+  using: node16
   main: lib/index.js
 branding:
   color: purple


### PR DESCRIPTION
using node16 for M1 compatibility which fixes this error:
`The node12 is not supported on macOS ARM64 platform. Use node16 instead. `