### PR TITLE
Fix arch in release.ts

### DIFF
--- a/github-release-download/src/release.ts
+++ b/github-release-download/src/release.ts
@@ -236,7 +236,7 @@ function getFileNameWithoutExtension(tool: string, version: string): string {
   const stripped_version =
     version[0] === "v" ? version.slice(1, version.length) : version;
   const os: string = osPlat == "win32" ? "windows" : osPlat;
-  const arch: string = osArch == "x64" ? "amd64" : "386";
+  const arch: string = osArch == "x64" ? "amd64" : "arm64";
   return fmt
     .replace("$OS", os)
     .replace("$ARCH", arch)


### PR DESCRIPTION
I was able to do a workaround for the gitHub-release-download by hardcoding the release-name

`release_format: $TOOL-$OS-arm64 `

Node's os.arch() returns arm64 on M1 Mac and x64 on Intel Mac