### PR TITLE
Upgrade actions to run on node20

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
       - name: GolangCI-Lint
         id: release_download
         uses: ./github-release-download
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
       - name: Set Environment
         uses: ./set-environment-variables
         env:
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
       - name: Get Terraform
         uses: ./setup-terraform
         with:

--- a/github-release-download/action.yml
+++ b/github-release-download/action.yml
@@ -34,7 +34,7 @@ outputs:
   download_path:
     description: Location of the uncompressed files
 runs:
-  using: node16
+  using: node20
   main: lib/index.js
 branding:
   color: purple

--- a/set-environment-variables/action.yml
+++ b/set-environment-variables/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Environment variable names (comma separated list with no spaces) to setup
     required: true
 runs:
-  using: node16
+  using: node20
   main: lib/index.js
 branding:
   color: purple

--- a/setup-terraform/action.yml
+++ b/setup-terraform/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Version of Terraform to install
     required: true
 runs:
-  using: node16
+  using: node20
   main: lib/index.js
 branding:
   color: purple


### PR DESCRIPTION
This pr updates the workflow and actions to node v20 as node v16 has been deprecated per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/