### PR TITLE
ci: add Dependabot config for npm + github-actions (SRE-4315)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/github-release-download"
+      - "/set-environment-variables"
+      - "/setup-terraform"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      actions-toolkit:
+        patterns:
+          - "@actions/*"
+      types:
+        patterns:
+          - "@types/*"


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yaml` so Dependabot opens version-update PRs for the three npm subpackages and for the github-actions used in workflows. The repo previously had no Dependabot config — only security scanning was active, which is why **15 undici security alerts (6 HIGH severity, CVSS 7.5)** have been piling up with no PR proposed.

## Why now
This config doesn't fix today's undici alerts (those need a major bump of `@actions/http-client`, tracked separately in [SRE-4355](https://acstchms.atlassian.net/browse/SRE-4355)). It does prevent new dependency drift from going invisible.

## What this enables
| Ecosystem | Directory | Cadence | Group |
|---|---|---|---|
| github-actions | / | weekly | — |
| npm | /github-release-download | weekly | @actions/*, @types/* grouped |
| npm | /set-environment-variables | weekly | @actions/*, @types/* grouped |
| npm | /setup-terraform | weekly | @actions/*, @types/* grouped |

Cooldowns: 3d patch / 7d minor / 30d major / 5d default.

## Test plan
- [ ] After merge, watch the next Dependabot daily scan — expect new PRs for any pending npm/action updates.
- [ ] SRE-4355 follow-up: bump @actions/http-client 2.x → 4.x to actually clear the undici alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SRE-4355]: https://acstchms.atlassian.net/browse/SRE-4355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ