### PR TITLE
Add dependabot.yml to cover all three action directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /github-release-download
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: /set-environment-variables
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: /setup-terraform
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to explicitly configure weekly npm dependency updates for all three action subdirectories: `github-release-download`, `set-environment-variables`, and `setup-terraform`

## Why

No `dependabot.yml` existed in this repo. Dependabot auto-detected `github-release-download` and `set-environment-variables` and opened PRs for the recent `uuid` CVE (GHSA-uuid-buffer-bounds), but silently skipped `setup-terraform`. Alert [#149](https://github.com/acst/actions/security/dependabot/149) has been open since 2026-05-21 with no corresponding PR generated.

Explicit config ensures all directories are scanned on the same cadence going forward.

## Test plan

- [ ] Confirm Dependabot opens a PR for `uuid` bump in `/setup-terraform` after merge
- [ ] Confirm weekly update schedule appears in the repo's Dependabot insights page